### PR TITLE
Add text field to let users enter their own project names

### DIFF
--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -110,11 +110,15 @@ export default function Editor() {
         &nbsp;
         <Button onClick={loadDesign}>Load</Button>
         &nbsp;
-        <Button onClick={saveDesign} disabled={projectName() === ''}>Save</Button>
+        <Button onClick={saveDesign} disabled={projectName() === ''}>
+          Save
+        </Button>
         &nbsp;
         <Button onClick={clear}>Clear</Button>
         &nbsp;
-        <Button onClick={saveSTL} disabled={projectName() === ''}>STL</Button>
+        <Button onClick={saveSTL} disabled={projectName() === ''}>
+          STL
+        </Button>
       </div>
       <div style={{ display: 'flex', 'margin-top': '12px' }}>
         <Canvas size={canvasSize() * 200} />

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -13,16 +13,16 @@ import { round2dp } from '~/utils/math';
 import Canvas from './Canvas';
 import CrossSectionSlider from './CrossSectionSlider';
 import Presets from './Presets';
-import { createSignal } from 'solid-js'
+import { createSignal } from 'solid-js';
 
 export default function Editor() {
-  const [projectName, setProjectName] = createSignal('my-siliwiz-project')
+  const [projectName, setProjectName] = createSignal('my-siliwiz-project');
 
   const loadDesign = async () => {
     const files = await openFiles({ accept: ['application/json'] });
     const text = await files?.item(0)?.text();
     const filename = files?.item(0)?.name;
-    
+
     if (text == null || filename == null) {
       return;
     }
@@ -34,7 +34,7 @@ export default function Editor() {
       alert('Error: unsupported file version');
     }
     loadPreset(frozenLayout);
-    setProjectName(filename.toString().substring(0, filename.lastIndexOf('.')))
+    setProjectName(filename.toString().substring(0, filename.lastIndexOf('.')));
   };
 
   const saveDesign = () => {
@@ -65,8 +65,8 @@ export default function Editor() {
   };
 
   const saveSTL = () => {
-    exportSTL(projectName())
-  }
+    exportSTL(projectName());
+  };
 
   const clear = () => {
     setLayout('rects', []);

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -88,6 +88,8 @@ export default function Editor() {
           onChange={(e) => {
             setProjectName(e.target.value);
           }}
+          error={projectName() === ''}
+          helperText={projectName() === '' ? 'Cannot be empty!' : ''}
         />
         <br />
         <IconButton
@@ -108,11 +110,11 @@ export default function Editor() {
         &nbsp;
         <Button onClick={loadDesign}>Load</Button>
         &nbsp;
-        <Button onClick={saveDesign}>Save</Button>
+        <Button onClick={saveDesign} disabled={projectName() === ''}>Save</Button>
         &nbsp;
         <Button onClick={clear}>Clear</Button>
         &nbsp;
-        <Button onClick={saveSTL}>STL</Button>
+        <Button onClick={saveSTL} disabled={projectName() === ''}>STL</Button>
       </div>
       <div style={{ display: 'flex', 'margin-top': '12px' }}>
         <Canvas size={canvasSize() * 200} />

--- a/src/model/stl.ts
+++ b/src/model/stl.ts
@@ -6,7 +6,7 @@ import { downloadFile } from '~/utils/download-file';
 import { layerTypes } from './layerTypes';
 import { layout } from './layout';
 
-export function exportSTL() {
+export function exportSTL(projectname: string) {
   const exporter = new STLExporter();
 
   const scene = new Group();
@@ -25,5 +25,5 @@ export function exportSTL() {
   }
 
   const result = exporter.parse(scene, { binary: true }) as unknown as ArrayBuffer;
-  downloadFile('siliwiz.stl', result);
+  downloadFile(projectname.concat('.stl'), result);
 }


### PR DESCRIPTION
Adds a field in the Editor component to allow users to set a string as the project name. Downloaded json and stl files have this as the filename, and loaded json filenames restore the project name.

I'm just tinkering, please let me know and close if this isn't welcome.